### PR TITLE
Update the retrieval of package version in pypi workflow

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(python setup.py -V)"
+          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2


### PR DESCRIPTION
Package version should be retrieved from pyproject.toml instead of setup.py. This PR updates the pypi workflow.