### PR TITLE
Pypi workflow update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
 # [Option] Install Node.js
-ARG INSTALL_NODE="true"
+ARG INSTALL_NODE="false"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -7,6 +7,6 @@ jobs:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
       package_version: 2.1.5
-      test_pypi: "true"
+      test_pypi: "false"
       python_latest: false
     secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,12 +1,12 @@
 name: Call PyPI publish workflow
 on:
-  push:
-    # types: [published]
+  release:
+    types: [published]
 jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
-      package_version: 2.1.4
+      package_version: 2.1.5
       test_pypi: "true"
       python_latest: false
     secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,74 +1,12 @@
-name: PyPI Publish
-
+name: Call PyPI publish workflow
 on:
   release:
-    types: [published]
-
+    # types: [published]
 jobs:
-  pypi-publish:
-    name: Publish tagged release on PyPI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Ensure package version and tag are equal
-        run: |
-
-          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
-          TAG_VER="${GITHUB_REF##*/}"
-
-          echo "Package version is $PKG_VER" >&2
-          echo "Tag version is $TAG_VER" >&2
-          if [ "$PKG_VER" != "$TAG_VER" ]; then
-            echo "Package version and tag name mismatch." >&2
-            exit 1
-          fi
-
-      - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
-
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
-
-      - name: Install the newly built package with all extras
-        run: |
-          TAR_PATH="$( realpath ./dist/*.tar.gz)"
-          python -m \
-            pip install \
-            "${TAR_PATH}[all]"
-
-      - name: Install testing requirements
-        run: >-
-          python -m
-          pip install
-          --no-deps -r ./lock/requirements-dev.txt
-
-      - name: Run pytest on freshly installed package
-        run: |
-          pytest .
-
-      - name: Publish distribution package to PyPI (test)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
-      - name: Publish distribution package to PyPI (production)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  call-pypi-publish:
+    uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
+    with:
+      package_version: 2.1.5
+      test_pypi: "true"
+      python_latest: false
+    secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,12 +1,12 @@
 name: Call PyPI publish workflow
 on:
-  release:
+  push:
     # types: [published]
 jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
-      package_version: 2.1.5
+      package_version: 2.1.4
       test_pypi: "true"
       python_latest: false
     secrets: inherit

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ghga_transpiler"
 
-version = "2.1.4"
+version = "2.1.5"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -7,7 +7,7 @@ dependencies = [
     "typer >= 0.12",
     "openpyxl >= 3.1.2, == 3.*",
     "defusedxml >= 0.7, == 0.*",
-    "pydantic >=2, <3",
+    "pydantic >=2.6, <3",
     "PyYAML ~= 6.0",
     "semver == 3.*",
     'exceptiongroup>=1.0.0; python_version < "3.11"',

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -11,7 +11,8 @@ dependencies = [
     "PyYAML ~= 6.0",
     "semver == 3.*",
     'exceptiongroup>=1.0.0; python_version < "3.11"',
-    'tomli>= 2.0.0; python_version < "3.11"'
+    'tomli>= 2.0.0; python_version < "3.11"',
+    'eval-type-backport==0.2.0; python_version < "3.10"'
 ]
 
 [project.urls]

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ghga_transpiler"
 
-version = "2.1.5"
+version = "2.1.4"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ghga_transpiler"
 
-version = "2.1.4"
+version = "2.1.5"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",
@@ -9,7 +9,7 @@ dependencies = [
     "defusedxml >= 0.7, == 0.*",
     "pydantic >=2, <3",
     "PyYAML ~= 6.0",
-    "semver == 3.*"
+    "semver == 3.*",
 ]
 
 [project.urls]

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -10,6 +10,8 @@ dependencies = [
     "pydantic >=2, <3",
     "PyYAML ~= 6.0",
     "semver == 3.*",
+    'exceptiongroup>=1.0.0; python_version < "3.11"',
+    'tomli>= 2.0.0; python_version < "3.11"'
 ]
 
 [project.urls]

--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -33,7 +33,6 @@ exclude = [
 ]
 line-length = 88
 src = ["src", "tests", "examples", "scripts"]
-target-version = "py39"
 
 [tool.ruff.lint]
 fixable = [

--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 authors = [
     { name = "German Human Genome Phenome Archive (GHGA)", email = "contact@ghga.de" },
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 license = { text = "Apache 2.0" }
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -33,7 +33,7 @@ exclude = [
 ]
 line-length = 88
 src = ["src", "tests", "examples", "scripts"]
-target-version = "py312"
+target-version = "py39"
 
 [tool.ruff.lint]
 fixable = [

--- a/.template/static_files_ignore.txt
+++ b/.template/static_files_ignore.txt
@@ -9,3 +9,5 @@ scripts/update_readme.py
 .github/workflows/check_readme.yaml
 
 .pre-commit-config.yaml
+
+.pyproject_generation/pyproject_template.toml

--- a/.template/static_files_ignore.txt
+++ b/.template/static_files_ignore.txt
@@ -3,6 +3,8 @@
 
 scripts/update_openapi_docs.py
 scripts/update_readme.py
+scripts/script_utils/deps.py
+scripts/update_pyproject.py
 
 .github/workflows/check_config_docs.yaml
 .github/workflows/check_openapi_spec.yaml

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -1,7 +1,7 @@
 # common requirements for development and testing of services
 
 pytest>=8.2
-pytest-asyncio>=0.23.6
+pytest-asyncio>=0.23.7
 pytest-cov>=5
 snakeviz>=2.2
 logot>=1.3
@@ -29,4 +29,4 @@ setuptools>=69.5
 # required since switch to pyproject.toml and pip-tools
 tomli_w>=1.0
 
-uv>=0.1.44
+uv>=0.2.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_transpiler"
-version = "2.1.4"
+version = "2.1.5"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "pydantic >=2, <3",
     "PyYAML ~= 6.0",
     "semver == 3.*",
+    "exceptiongroup>=1.0.0; python_version < \"3.11\"",
+    "tomli>=2.0.0; python_version < \"3.11\"",
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "typer >= 0.12",
     "openpyxl >= 3.1.2, == 3.*",
     "defusedxml >= 0.7, == 0.*",
-    "pydantic >=2, <3",
+    "pydantic >=2.6, <3",
     "PyYAML ~= 6.0",
     "semver == 3.*",
     "exceptiongroup>=1.0.0; python_version < \"3.11\"",
@@ -69,7 +69,6 @@ src = [
     "examples",
     "scripts",
 ]
-target-version = "py39"
 
 [tool.ruff.lint]
 fixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "PyYAML ~= 6.0",
     "semver == 3.*",
     "exceptiongroup>=1.0.0; python_version < \"3.11\"",
-    "tomli>=2.0.0; python_version < \"3.11\"",
+    "tomli>= 2.0.0; python_version < \"3.11\"",
+    "eval-type-backport==0.2.0; python_version < \"3.10\"",
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [
     { name = "German Human Genome Phenome Archive (GHGA)", email = "contact@ghga.de" },
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 1 - Planning",
     "Operating System :: POSIX :: Linux",
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_transpiler"
-version = "2.1.4"
+version = "2.1.5"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",
@@ -66,7 +66,7 @@ src = [
     "examples",
     "scripts",
 ]
-target-version = "py312"
+target-version = "py39"
 
 [tool.ruff.lint]
 fixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_transpiler"
-version = "2.1.5"
+version = "2.1.4"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/scripts/script_utils/deps.py
+++ b/scripts/script_utils/deps.py
@@ -15,12 +15,12 @@
 #
 """Contains utils for working with dependencies, lock files, etc."""
 
-import tomllib
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 import stringcase
+import tomllib
 
 
 def exclude_from_dependency_list(*, package_name: str, dependencies: list) -> list:

--- a/scripts/update_pyproject.py
+++ b/scripts/update_pyproject.py
@@ -19,10 +19,10 @@
 """A script to update the pyproject.toml."""
 
 import sys
-import tomllib
 from pathlib import Path
 
 import tomli_w
+import tomllib
 
 from script_utils import cli
 

--- a/src/ghga_transpiler/__init__.py
+++ b/src/ghga_transpiler/__init__.py
@@ -18,7 +18,7 @@
 
 from openpyxl.xml import DEFUSEDXML
 
-__version__ = "2.1.5"
+__version__ = "2.1.4"
 
 if not DEFUSEDXML:
     raise RuntimeError(

--- a/src/ghga_transpiler/__init__.py
+++ b/src/ghga_transpiler/__init__.py
@@ -18,7 +18,7 @@
 
 from openpyxl.xml import DEFUSEDXML
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 if not DEFUSEDXML:
     raise RuntimeError(

--- a/src/ghga_transpiler/cli.py
+++ b/src/ghga_transpiler/cli.py
@@ -45,7 +45,7 @@ def transpile(
         dir_okay=False,
         readable=True,
     ),
-    output_file: Optional[Path] = typer.Argument(  # noqa: UP007 (typer issue #461)
+    output_file: Optional[Path] = typer.Argument(
         None, help="The path to output file (JSON).", dir_okay=False
     ),
     force: bool = typer.Option(

--- a/src/ghga_transpiler/config/config.py
+++ b/src/ghga_transpiler/config/config.py
@@ -17,6 +17,8 @@
 
 """Module to process config file"""
 
+from __future__ import annotations
+
 from collections import Counter
 from collections.abc import Callable
 from importlib import resources

--- a/src/ghga_transpiler/core.py
+++ b/src/ghga_transpiler/core.py
@@ -17,6 +17,8 @@
 
 """This module contains functionalities for processing excel sheets into json object."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from importlib import resources
 
@@ -97,7 +99,7 @@ def convert_rows(header, rows) -> list[dict]:
     return [
         {
             key: value
-            for key, value in zip(header, row, strict=False)
+            for key, value in zip(header, row)
             if value is not None and value != ""
         }
         for row in rows

--- a/src/ghga_transpiler/io.py
+++ b/src/ghga_transpiler/io.py
@@ -17,6 +17,8 @@
 
 """IO related functionality"""
 
+from __future__ import annotations
+
 import json
 import sys
 from importlib import resources

--- a/src/ghga_transpiler/transformations.py
+++ b/src/ghga_transpiler/transformations.py
@@ -36,7 +36,7 @@ def to_attributes() -> Callable:
     def split_one(value: str) -> dict:
         """Returns a dictionary with key, value as keys, splitted string as values"""
         splitted = (elem.strip() for elem in value.split("="))
-        return dict(zip(("key", "value"), splitted, strict=False))
+        return dict(zip(("key", "value"), splitted))
 
     def split_mult(value: str) -> list[dict]:
         """Converts string to attributes"""


### PR DESCRIPTION
This PR includes a caller workflow that runs [pypi_publish](https://github.com/ghga-de/gh-action-pypi/blob/main/.github/workflows/pypi_publish.yml) for ghga-transpiler.  

The workflow tests the ghga-transpiler package on Python 3.9, 3.10, 3.11, and 3.12. Since the development environment is Python 3.12, package-dependency inconsistencies arose while testing the transpiler on Python 3.9. [eval-type-backport](https://github.com/pydantic/pydantic/pull/8209) is added to solve the TypeError due to `|` operand for type unions in Pydantic models on Python 3.9. Additionally, `exceptiongroup` and `tomli` are incorporated to address the requirements of pytest and mypy respectively for Python versions earlier than 3.11.

Since `tomllib` is not a standard library in Python 3.9, the import order is different from the template for the files `deps.py` and `update_pyproject.py`. Thus they are added to `static_file_ignore` to pass the template checks. 

