### PR TITLE
Config fix for default transformations

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -6,7 +6,7 @@ jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
-      package_version: 2.2.0
+      package_version: 2.2.1
       test_pypi: "false"
       python_latest: false
     secrets: inherit

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ghga_transpiler"
 
-version = "2.2.0"
+version = "2.2.1"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_transpiler"
-version = "2.2.0"
+version = "2.2.1"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/src/ghga_transpiler/__init__.py
+++ b/src/ghga_transpiler/__init__.py
@@ -18,7 +18,7 @@
 
 from openpyxl.xml import DEFUSEDXML
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 if not DEFUSEDXML:
     raise RuntimeError(

--- a/src/ghga_transpiler/configs/2.0.yaml
+++ b/src/ghga_transpiler/configs/2.0.yaml
@@ -39,6 +39,8 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_attributes []
         types:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case_list []
+        attributes:
+          !!python/object/apply:ghga_transpiler.transformations.to_attributes []
     sheet_name: Study
   - settings:
       end_column: 10
@@ -84,6 +86,8 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
         biospecimen_storage:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
+        attributes:
+          !!python/object/apply:ghga_transpiler.transformations.to_attributes []
     sheet_name: Sample
   - settings:
       end_column: 23
@@ -113,6 +117,8 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
         sequencing_layout:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
+        attributes:
+          !!python/object/apply:ghga_transpiler.transformations.to_attributes []
     sheet_name: ExperimentMethod
   - settings:
       end_column: 7
@@ -128,6 +134,8 @@ worksheets:
       transformations:
         experiments:
           !!python/object/apply:ghga_transpiler.transformations.to_list []
+        format:
+          !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
     sheet_name: ResearchDataFile
   - settings:
       end_column: 7


### PR DESCRIPTION
This PR includes a config fix, that adds `attributes` and `format` transformations to the classes that do not inherit the default transformations defined under default settings 