### PR TITLE
Config update for metadata schema 2.2.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+FROM mcr.microsoft.com/devcontainers/python:2.0.2-3.13-trixie
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 # Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
 ARG USER_UID=1000

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -11,11 +11,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v6
+        with:
+          python-version: '3.13'
 
       - name: Check pyproject.toml
         id: check-pyproject

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Check template files
         id: check-template-files

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -11,11 +11,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v6
+        with:
+          python-version: '3.13'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ghga_transpiler"
 
-version = "2.3.2"
+version = "2.4.0"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/.readme_generation/readme_template.md
+++ b/.readme_generation/readme_template.md
@@ -13,7 +13,7 @@ $description
 
 We recommend using the provided Docker container.
 
-A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/$name):
+A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/$name):
 ```bash
 docker pull ghga/$name:$version
 ```
@@ -24,11 +24,11 @@ Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 docker build -t ghga/$name:$version .
 ```
 
-For production-ready deployment, we recommend using Kubernetes, however,
-for simple use cases, you could execute the service using docker
+For production-ready deployment, we recommend using Kubernetes.
+However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
-# The entrypoint is preconfigured:
+# The entrypoint is pre-configured:
 docker run -p 8080:8080 ghga/$name:$version --help
 ```
 
@@ -50,18 +50,18 @@ $config_description
 
 ### Usage:
 
-A template YAML for configuring the service can be found at
-[`./example-config.yaml`](./example-config.yaml).
+A template YAML file for configuring the service can be found at
+[`./example_config.yaml`](./example_config.yaml).
 Please adapt it, rename it to `.$shortname.yaml`, and place it in one of the following locations:
 - in the current working directory where you execute the service (on Linux: `./.$shortname.yaml`)
 - in your home directory (on Linux: `~/.$shortname.yaml`)
 
-The config yaml will be automatically parsed by the service.
+The config YAML file will be automatically parsed by the service.
 
 **Important: If you are using containers, the locations refer to paths within the container.**
 
-All parameters mentioned in the [`./example-config.yaml`](./example-config.yaml)
-could also be set using environment variables or file secrets.
+All parameters mentioned in the [`./example_config.yaml`](./example_config.yaml)
+can also be set using environment variables or file secrets.
 
 For naming the environment variables, just prefix the parameter name with `${shortname}_`,
 e.g. for the `host` set an environment variable named `${shortname}_host`
@@ -95,12 +95,12 @@ This will give you a full-fledged, pre-configured development environment includ
 - a pre-configured debugger
 - automatic license-header insertion
 
-Moreover, inside the devcontainer, a command `dev_install` is available for convenience.
+Inside the devcontainer, a command `dev_install` is available for convenience.
 It installs the service with all development dependencies, and it installs pre-commit.
 
 The installation is performed automatically when you build the devcontainer. However,
 if you update dependencies in the [`./pyproject.toml`](./pyproject.toml) or the
-[`./requirements-dev.txt`](./requirements-dev.txt), please run it again.
+[`lock/requirements-dev.txt`](./lock/requirements-dev.txt), run it again.
 
 ## License
 
@@ -109,5 +109,5 @@ This repository is free to use and modify according to the
 
 ## README Generation
 
-This README file is auto-generated, please see [`readme_generation.md`](./readme_generation.md)
+This README file is auto-generated, please see [.readme_generation/README.md](./.readme_generation/README.md)
 for details.

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -1,32 +1,33 @@
 # common requirements for development and testing of services
 
-pytest>=8.3
-pytest-asyncio>=0.26
-pytest-cov>=6.1
+pytest>=8.4
+pytest-asyncio>=1.2.0
+pytest-cov>=7
 snakeviz>=2.2
-logot>=1.3
+logot>=1.5.1
 
-pre-commit>=4.2
+pre-commit>=4.3
 
-mypy>=1.15
-mypy-extensions>=1.0
+mypy>=1.18.2
+mypy-extensions>=1.1
 
-ruff>=0.11
+ruff>=0.13.1
 
-click>=8.1
-typer>=0.15
+click>=8.3
+typer>=0.19.1
 
-httpx>=0.28
+httpx>=0.28.1
 pytest-httpx>=0.35
 
-urllib3>=2.4
-requests>=2.32
+urllib3>=2.5
+requests>=2.32.5
 
 casefy>=1.1
-jsonschema2md>=1.5
-setuptools>=80.3
+jsonschema2md>=1.7
+setuptools>=80.9
 
 # required since switch to pyproject.toml and pip-tools
+tomli>=2.2.1
 tomli_w>=1.2
 
-uv>=0.7.2
+uv>=0.8.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_transpiler"
-version = "2.3.2"
+version = "2.4.0"
 description = "GHGA-Transpiler - excel to JSON converter"
 dependencies = [
     "typer >= 0.12",

--- a/scripts/update_config_docs.py
+++ b/scripts/update_config_docs.py
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generates a JSON schema from the service's Config class as well as a corresponding
-example config yaml (or check whether these files are up to date).
+"""Generate a JSON Schema from the service's Config class and an example
+config YAML file, or check whether the existing files are up to date.
 """
 
 import importlib
@@ -46,7 +46,7 @@ class ValidationError(RuntimeError):
 def get_config_class():
     """
     Dynamically imports and returns the Config class from the current service.
-    This makes the script service repo agnostic.
+    This makes the script agnostic to the service repository.
     """
     # get the name of the microservice package
     with subprocess.Popen(
@@ -76,35 +76,28 @@ def get_schema() -> str:
     """Returns a JSON schema generated from a Config class."""
 
     config = get_dev_config()
-    return config.schema_json(indent=2)  # change eventually to .model_json_schema(...)
+    schema_dict = type(config).model_json_schema()
+    return json.dumps(schema_dict, indent=2)
 
 
 def get_example() -> str:
     """Returns an example config YAML."""
-
     config = get_dev_config()
-    normalized_config_dict = json.loads(
-        config.json()  # change eventually to .model_dump_json()
-    )
-    return yaml.dump(normalized_config_dict)  # pyright: ignore
+    normalized_config_dict = config.model_dump(mode="json", by_alias=True)
+    return yaml.dump(normalized_config_dict, indent=2, sort_keys=True)
 
 
 def update_docs():
-    """Update the example config and config schema files documenting the config
-    options."""
-
-    example = get_example()
-    with open(EXAMPLE_CONFIG_YAML, "w", encoding="utf-8") as example_file:
-        example_file.write(example)
-
-    schema = get_schema()
-    with open(CONFIG_SCHEMA_JSON, "w", encoding="utf-8") as schema_file:
-        schema_file.write(schema)
+    """Update the example config YAML and JSON Schema files documenting the
+    config options.
+    """
+    EXAMPLE_CONFIG_YAML.write_text(get_example(), encoding="utf-8")
+    CONFIG_SCHEMA_JSON.write_text(get_schema(), encoding="utf-8")
 
 
 def print_diff(expected: str, observed: str):
-    """Print differences between expected and observed files."""
-    echo_failure("Differences in Config YAML:")
+    """Print differences between expected and observed example config YAML."""
+    echo_failure("Differences in config YAML file:")
     for line in unified_diff(
         expected.splitlines(keepends=True),
         observed.splitlines(keepends=True),
@@ -115,28 +108,25 @@ def print_diff(expected: str, observed: str):
 
 
 def check_docs():
-    """Check whether the example config and config schema files documenting the config
-    options are up to date.
+    """Check whether the example config YAML and JSON Schema files are up to date.
 
     Raises:
-        ValidationError: if not up to date.
+        ValidationError: If not up to date.
     """
 
     example_expected = get_example()
-    with open(EXAMPLE_CONFIG_YAML, encoding="utf-8") as example_file:
-        example_observed = example_file.read()
+    example_observed = EXAMPLE_CONFIG_YAML.read_text(encoding="utf-8")
     if example_expected != example_observed:
         print_diff(example_expected, example_observed)
         raise ValidationError(
-            f"Example config YAML at '{EXAMPLE_CONFIG_YAML}' is not up to date."
+            f"Example config YAML file at '{EXAMPLE_CONFIG_YAML}' is not up to date."
         )
 
     schema_expected = get_schema()
-    with open(CONFIG_SCHEMA_JSON, encoding="utf-8") as schema_file:
-        schema_observed = schema_file.read()
+    schema_observed = CONFIG_SCHEMA_JSON.read_text(encoding="utf-8")
     if schema_expected != schema_observed:
         raise ValidationError(
-            f"Config schema JSON at '{CONFIG_SCHEMA_JSON}' is not up to date."
+            f"Config schema JSON file at '{CONFIG_SCHEMA_JSON}' is not up to date."
         )
 
 

--- a/src/ghga_transpiler/configs/2.1.yaml
+++ b/src/ghga_transpiler/configs/2.1.yaml
@@ -121,6 +121,8 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
         attributes:
           !!python/object/apply:ghga_transpiler.transformations.to_attributes []
+        sequencing_read_length:
+          !!python/name:ghga_transpiler.transformations.to_string
     sheet_name: ExperimentMethod
   - settings:
       end_column: 7
@@ -138,6 +140,8 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_list []
         format:
           !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
+        sequencing_lane_id:
+          !!python/name:ghga_transpiler.transformations.to_string
     sheet_name: ResearchDataFile
   - settings:
       end_column: 7

--- a/src/ghga_transpiler/configs/2.2.yaml
+++ b/src/ghga_transpiler/configs/2.2.yaml
@@ -1,4 +1,4 @@
-ghga_metadata_version: 2.0.0
+ghga_metadata_version: 2.2.0
 default_settings:
   header_row: 1
   start_row: 7
@@ -17,12 +17,16 @@ worksheets:
           !!python/object/apply:ghga_transpiler.transformations.to_list []
     sheet_name: Analysis
   - settings:
-      end_column: 11
+      end_column: 17
       name: analysis_methods
       transformations:
+        reference_type:
+          !!python/object/apply:ghga_transpiler.transformations.to_snake_case []
         parameters:
           !!python/object/apply:ghga_transpiler.transformations.to_attributes []
         software_versions:
+          !!python/object/apply:ghga_transpiler.transformations.to_attributes []
+        attributes:
           !!python/object/apply:ghga_transpiler.transformations.to_attributes []
     sheet_name: AnalysisMethod
   - settings:

--- a/src/ghga_transpiler/transformations.py
+++ b/src/ghga_transpiler/transformations.py
@@ -20,6 +20,11 @@
 from collections.abc import Callable
 
 
+def to_string(value: int | str) -> str:
+    """Converts a value to string"""
+    return str(value)
+
+
 def split_by_semicolon(value: str) -> list[str]:
     """Splits a string by semicolon"""
     return [elem.strip() for elem in value.split(";")]


### PR DESCRIPTION
This PR adds a configuration file compatible with ghga-metadata-schema 2.2.0. In addition, it introduces a transformation function applied to the fields `ExperimentMethod.sequencing_read_length` and `ResearchDataFile.sequencing_lane_id,` converting user-provided integer values into strings, as required by the metadata model. 